### PR TITLE
This fixes the crash in sentiment.Restore()

### DIFF
--- a/init.go
+++ b/init.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/cdipaolo/goml/base"
 )
@@ -45,6 +46,10 @@ func RestoreModels(bytes []byte) (Models, error) {
 
 	for i := range models {
 		models[i].UpdateSanitize(base.OnlyWords)
+		models[i].UpdateTokenizer(
+			func(input string) []string {
+				return strings.Split(strings.ToLower(input), " ")
+			})
 	}
 
 	return models, nil


### PR DESCRIPTION
The crash in sentiment.Restore() is caused by the fact that
The tokenizer is not restored in goml after Unmarshal from json
This is likely not the best place to make this change as the issue
is in the goml library. A couple better fixes should likely be done.

1) Privide a Marshal/Unmarshal function as part of the NaiveBayes type
that would restore the tokenizer

2) Make the spaceTokenizer public. This would avoid the duplication of
code this change makes but would mean a manual process for restoring the
tokenizer after Unmarshaling

I perfer the former if possible. Unless it's intended to wrap all the json
functionality up somewhere elase and pull all the json references out of
bayes.go then bayes.go should be able to Marshal/Unmarshal with out
leading to a crash. This would mean also changing sentiment to accomidate that.

I went for this quick and dirty change to keep moving, open up discustion,
trigger the proper change, and avoid making dependant changes in multiple
repos.

@cdipaolo What do you think would be the best/correct way to approach this fix ?