### PR TITLE
Match the new UpdateTokenizer func

### DIFF
--- a/init.go
+++ b/init.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/cdipaolo/goml/base"
+	"github.com/cdipaolo/goml/text"
 )
 
 const (
@@ -46,10 +46,7 @@ func RestoreModels(bytes []byte) (Models, error) {
 
 	for i := range models {
 		models[i].UpdateSanitize(base.OnlyWords)
-		models[i].UpdateTokenizer(
-			func(input string) []string {
-				return strings.Split(strings.ToLower(input), " ")
-			})
+		models[i].UpdateTokenizer(&text.SimpleTokenizer{SplitOn: " "})
 	}
 
 	return models, nil


### PR DESCRIPTION
This little commit just updates the call to NaiveBayes.UpdateTokenizer that changed in goml's [2dbc4](https://github.com/cdipaolo/goml/commit/2dbc4f28a7bb0940e79973a7344054f825f81641)