### PR TITLE
This fixed RestoreModels so it compiles

### DIFF
--- a/init.go
+++ b/init.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/cdipaolo/goml/base"
+	"github.com/cdipaolo/goml/text"
 )
 
 const (
@@ -44,12 +44,13 @@ func RestoreModels(bytes []byte) (Models, error) {
 		return nil, err
 	}
 
+	tokenizer := &text.SimpleTokenizer{
+		SplitOn: " ",
+	}
+
 	for i := range models {
 		models[i].UpdateSanitize(base.OnlyWords)
-		models[i].UpdateTokenizer(
-			func(input string) []string {
-				return strings.Split(strings.ToLower(input), " ")
-			})
+		models[i].UpdateTokenizer(tokenizer)
 	}
 
 	return models, nil


### PR DESCRIPTION
Golangs interfaces cannot be satisfied anonymously. Switched to using the SimpleTokenizer in place of the anonymous function.

Attempting to compile from master now gives the following error:

`./init.go:50: cannot use func literal (type func(string) []string) as type text.Tokenizer in argument to models[i].UpdateTokenizer:
	func(string) []string does not implement text.Tokenizer (missing Tokenize method)`